### PR TITLE
fix: 修复因错误的正则导致匹配TeX右侧$符号添加错误的空格

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -214,15 +214,61 @@ function transformTex(text, isBlock = false) {
 }
 
 function fixMathDollarSpacing(input) {
-  // 1. 逐一匹配所有 $公式$ 块
-  return input.replace(/(\S)?(\$[^$]+?\$)/g, (match, p1, p2) => {
-    // 只有 p1 存在且不是空白时在 $ 前加一个空格
-    if (p1 && !/\s/.test(p1)) {
-      return p1 + ' ' + p2;
-    }
-    // 否则直接返回原样（包括行首、或者p1为空、空格、\n等）
-    return (p1 || '') + p2;
+  // 匹配单个$（前后不是$，也不是$$），只处理$xxx$，忽略$$xxx$$
+  return input.replace(
+      /(\S)?((?<!\$)\$[^$\n]+\$(?!\$))/g, // 只处理$...$，忽略$$...$$
+      (match, p1, p2) => {
+        if (p1 && !/\s/.test(p1)) {
+          return p1 + ' ' + p2;
+        }
+        return (p1 || '') + p2;
+      }
+  );
+}
+
+function fixTexDoubleEscapeInMarkdown(markdown) {
+  // 块级公式
+  markdown = markdown.replace(/\$\$([\s\S]*?)\$\$/g, (block, tex) => {
+    // 只还原 remark escape 的那批符号 (包括逗号「只用于 \,」)，保留其他所有 latex 命令
+    tex = tex
+        // remark-stringify会把 \, escape 成 \\,
+        .replace(/\\\\,/g, '\\,')
+        // remark-stringify会把下列符号前加单/双斜杠
+        .replace(/\\\\([_{}[$])/g, '$1')
+        .replace(/\\([_{}$])/g, '$1')
+        // 专门处理方括号的转义
+        .replace(/\\([[$])/g, '$1');
+    return `$$${tex}$$`;
   });
+
+  // 非块级，分段处理
+  let segments = [];
+  let lastIndex = 0;
+  markdown.replace(/\$\$([\s\S]*?)\$\$/g, (match, _tex, offset) => {
+    if (lastIndex < offset)
+      segments.push({ type: 'text', text: markdown.slice(lastIndex, offset) });
+    segments.push({ type: 'block', text: match });
+    lastIndex = offset + match.length;
+  });
+
+  if (lastIndex < markdown.length)
+    segments.push({ type: 'text', text: markdown.slice(lastIndex) });
+
+  segments = segments.map(seg => {
+    if (seg.type === 'text') {
+      return seg.text.replace(/(?<!\$)\$([^\n$]+?)\$(?!\$)/g, (_all, tex) => {
+        tex = tex
+            .replace(/\\\\,/g, '\\,')
+            .replace(/\\\\([_{}[\]$])/g, '$1')
+            .replace(/\\([_{}$])/g, '$1')
+            // 同样在行内公式中也需要处理方括号
+            .replace(/\\([$])/g, '$1');
+        return `$${tex}$`;
+      });
+    }
+    return seg.text;
+  });
+  return segments.join('');
 }
 
 async function astHtmlToMarkdown(node) {
@@ -242,5 +288,5 @@ async function astHtmlToMarkdown(node) {
     .use(remarkGfm)
     .use(remarkStringify)
     .process(html);
-  return fixMathDollarSpacing(html2Markdown.value);
+  return fixTexDoubleEscapeInMarkdown(fixMathDollarSpacing(html2Markdown.value));
 }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -214,12 +214,14 @@ function transformTex(text, isBlock = false) {
 }
 
 function fixMathDollarSpacing(input) {
-  // 匹配 $xxx$，捕获左侧一位（也可能啥都没有）
-  // (?<! ) 匹配非空格（零宽断言，排除已经是空格的）
-  // 支持开头等情况，(?:^|[^ \n\r\t])(\$[^$]+?\$)
-  return input.replace(/(^|\S)(\$[^$]+?\$)/g, (_match, p1, p2) => {
-    // 如果p1是开头，则只返回p2；否则前面加空格
-    return (p1 === '' ? '' : p1 + ' ') + p2;
+  // 1. 逐一匹配所有 $公式$ 块
+  return input.replace(/(\S)?(\$[^$]+?\$)/g, (match, p1, p2) => {
+    // 只有 p1 存在且不是空白时在 $ 前加一个空格
+    if (p1 && !/\s/.test(p1)) {
+      return p1 + ' ' + p2;
+    }
+    // 否则直接返回原样（包括行首、或者p1为空、空格、\n等）
+    return (p1 || '') + p2;
   });
 }
 


### PR DESCRIPTION
## 变更类型

* [x] 问题修复（bug fix）
* [ ] 新特性（new feature）
* [ ] 文档更新（docs）

## 主要变更内容

  1. 修复错误的正则匹配导致TeX右侧的$错误的添加了空格
  
## 变更动机与详细说明

> 19号提交的代码存在错误的正则匹配导致右侧出现空格

![image](https://github.com/user-attachments/assets/8f04595b-36b6-4037-bb35-71c5c8c24144)

![image](https://github.com/user-attachments/assets/2fb7755e-d462-40a6-9b59-874b224c89b5)

## 破坏性修改

* [x] 无（向下兼容）
* [ ] 有（请详细解释：\_\_\_\_\_\_\_\_\_\_）

**测试相关**

* [x] 已进行了人为测试，暂未发现问题，复制可以避免右侧错误正则匹配问题

**效果图**

![image](https://github.com/user-attachments/assets/ba2ea168-c1e4-4a7b-8637-9430577a3988)
![image](https://github.com/user-attachments/assets/1da63aaa-3474-45a4-8056-742cf9cfbb44)