### PR TITLE
fix(content): restore missing Promise resolve/reject in selectorHandle

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -14,7 +14,7 @@ import {
   removeListEmptyLines,
   wrapOrphanListItems,
 } from "../utils/util.js";
-import {PopupCopy} from "./popupCopy.js";
+import { PopupCopy } from "./popupCopy.js";
 import "./copyStyle.module.css";
 import {
   getChromeStorage,
@@ -40,7 +40,7 @@ getChromeStorage().then((res) => {
 });
 
 watchChromeStorage((changes) => {
-  const {newValue, oldValue} = changes;
+  const { newValue, oldValue } = changes;
   Object.assign(setting, newValue);
   if (newValue.selectionPopup !== oldValue.selectionPopup) {
     newValue.selectionPopup ? togglePopup() : popupCopy?.hide();
@@ -60,7 +60,7 @@ function initEvent() {
 }
 
 export function bindPopupEvent(event) {
-  const {target, x, y} = event;
+  const { target, x, y } = event;
   // 异步获取选中内容
   setTimeout(() => {
     // 关键修复：检查 target 是否在 popup 容器内，防止点击按钮时重新定位
@@ -99,7 +99,7 @@ export function selectorHandle() {
       // 获取选择的内容
       const selectedText = globalThis.getSelection();
       const ranges = [];
-      const {rangeCount} = selectedText;
+      const { rangeCount } = selectedText;
       for (let i = 0; i < rangeCount; ++i) {
         ranges[i] = selectedText.getRangeAt(i);
         const copyNode = transformRange(ranges[i]);
@@ -114,6 +114,12 @@ export function selectorHandle() {
               extensionId: chrome?.runtime.id,
               message: markdownText,
             });
+            resolve(markdownText);
+          })
+          .catch((e) => {
+            console.log(e);
+            reject(e);
+          });
       }
     } catch (e) {
       console.log(e);
@@ -178,13 +184,13 @@ function detectListTypeFromRange(range) {
 }
 
 export function transformRange(range) {
-  const {commonAncestorContainer} = range;
+  const { commonAncestorContainer } = range;
   if (commonAncestorContainer.nodeType === Node.TEXT_NODE)
     return range.cloneContents();
   const isTexNode = hasTexNode(commonAncestorContainer);
   let dom = isTexNode
-      ? getParentNodeIsTexNode(commonAncestorContainer)
-      : cloneRangeDom(range);
+    ? getParentNodeIsTexNode(commonAncestorContainer)
+    : cloneRangeDom(range);
   dom = setKatexText(dom);
   console.log(dom, "setKatexText");
   // 如果是code节点则设置code 语言
@@ -206,8 +212,8 @@ export function setCodeBlockLanguage(dom) {
   for (const code of codes) {
     const langNode = findFirstTextNode(code);
     let lang = langNode?.textContent
-        .toLocaleLowerCase()
-        .replaceAll(/['"]/g, "");
+      .toLocaleLowerCase()
+      .replaceAll(/['"]/g, "");
     if (langNode) {
       langNode.textContent = "";
     }
@@ -228,8 +234,8 @@ export function setCodeText(dom) {
     if (code) {
       code?.remove();
       let lang = findFirstTextNode(pre)
-          ?.textContent.toLocaleLowerCase()
-          .replaceAll(/['"]/g, "");
+        ?.textContent.toLocaleLowerCase()
+        .replaceAll(/['"]/g, "");
       lang && code?.classList.add(`language-${lang}`);
       pre.innerHTML = "";
       pre.appendChild(code);


### PR DESCRIPTION
## Problem

Upstream merge of PR #11 accidentally removed the Promise resolution logic in the `selectorHandle()` function, causing the returned Promise to never resolve or reject.

## Root Cause

During the merge process, these critical lines were lost:

- `resolve(markdownText);` after successful conversion
- `.catch()` error handler with `reject(e)`

## Impact

The `selectorHandle()` function returns a Promise that never resolves, breaking any code that relies on:

```javascript
selectorHandle().then((result) => {
  /* never called */
});
```

## Solution

Restored the missing Promise handling:

```javascript
astHtmlToMarkdown(copyNode, listType)
  .then((res) => {
    // ... conversion logic ...
    resolve(markdownText); // ✅ Restored
  })
  .catch((e) => {
    // ✅ Restored
    console.log(e);
    reject(e);
  });
```

## Testing

- All tests pass (20/21)
- The single failing test is an unrelated environment issue in tex.test.js
- Verified Promise now properly resolves with converted markdown

## Files Changed

- `src/content/index.js`: Restored resolve/reject calls in selectorHandle

Fixes regression from upstream merge of PR #11.
