### PR TITLE
fix(storage): handle undefined values in storage change events

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "match_about_blank": true,
+      "all_frames": true,
       "type": "module",
       "js": ["src/content/index.js"],
       "run_at": "document_end"

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -14,10 +14,10 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 /*
-* Establish a long connection to monitor the closing of the popup
-* Because when sendingMessage in the background, if the popup is not opened, an error will be reported
-* Error: Could not establish connection. Receiving end does not exist
-* */
+ * Establish a long connection to monitor the closing of the popup
+ * Because when sendingMessage in the background, if the popup is not opened, an error will be reported
+ * Error: Could not establish connection. Receiving end does not exist
+ * */
 chrome.runtime.onConnect.addListener((externalPort) => {
   externalPort.onDisconnect.addListener(() => {
     isOpenPopup = false;
@@ -41,7 +41,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 watchChromeStorage((changes) => {
   const { newValue, oldValue } = changes;
-  if (newValue.contextMenus !== oldValue.contextMenus) {
+  if (newValue && newValue.contextMenus !== oldValue?.contextMenus) {
     setContextMenus(newValue?.contextMenus);
   }
 });

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -41,9 +41,11 @@ getChromeStorage().then((res) => {
 
 watchChromeStorage((changes) => {
   const { newValue, oldValue } = changes;
-  Object.assign(setting, newValue);
-  if (newValue.selectionPopup !== oldValue.selectionPopup) {
-    newValue.selectionPopup ? togglePopup() : popupCopy?.hide();
+  if (newValue) {
+    Object.assign(setting, newValue);
+    if (newValue.selectionPopup !== oldValue?.selectionPopup) {
+      newValue.selectionPopup ? togglePopup() : popupCopy?.hide();
+    }
   }
 });
 // contentMenu click event
@@ -67,7 +69,7 @@ export function bindPopupEvent(event) {
     if (target !== popupCopy?.popup && !popupCopy?.popup?.contains(target)) {
       position.x = x;
       position.y = y;
-      if (!setting.selectionPopup) return;
+      if (!setting?.selectionPopup) return;
       togglePopup();
     }
   });
@@ -192,7 +194,6 @@ export function transformRange(range) {
     ? getParentNodeIsTexNode(commonAncestorContainer)
     : cloneRangeDom(range);
   dom = setKatexText(dom);
-  console.log(dom, "setKatexText");
   // 如果是code节点则设置code 语言
   if (typeof dom.querySelector === "function") {
     dom = setCodeText(dom);


### PR DESCRIPTION
## Problem

Extension fails on certain pages (e.g., https://leetcode.cn/leetbook/) with error:
```
TypeError: Cannot read properties of undefined (reading 'selectionPopup')
```

Additionally, content script doesn't work in iframe-based pages.

## Root Cause

1. `watchChromeStorage` callbacks assume `newValue` and `oldValue` always exist, but they can be `undefined` during initial storage setup
2. Content script is not injected into iframes, causing failures on sites that load content in iframes (like LeetCode LeetBook)

## Solution

1. **Added null safety checks** in both content and background scripts:
   - Check if `newValue` exists before accessing properties
   - Use optional chaining (`?.`) for `oldValue` access

2. **Added iframe support** in manifest.json:
   - Added `all_frames: true` to inject content script into all frames
   - Added `match_about_blank: true` to match about:blank pages

3. **Cleaned up debug code** - removed temporary console.log statements

## Changes

- `manifest.json`: Added `all_frames` and `match_about_blank` options
- `src/content/index.js`: Added null checks in `watchChromeStorage` callback and `bindPopupEvent`
- `src/background/index.js`: Added null checks in `watchChromeStorage` callback

## Testing

- Tested on LeetCode LeetBook pages (https://leetcode.cn/leetbook/) - now works correctly
- Tested on regular LeetCode problem pages - still works
- All existing tests pass
- No console errors observed

## Related Issue

Fixes compatibility issues with iframe-based websites.