### PR TITLE
Fix: Handle language names with spaces in code blocks

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -214,7 +214,8 @@ export function setCodeBlockLanguage(dom) {
     const langNode = findFirstTextNode(code);
     let lang = langNode?.textContent
       .toLocaleLowerCase()
-      .replaceAll(/['"]/g, "");
+      .replaceAll(/['"]/g, "")
+      .replaceAll(/\s+/g, "-");
     if (langNode) {
       langNode.textContent = "";
     }
@@ -236,7 +237,8 @@ export function setCodeText(dom) {
       code?.remove();
       let lang = findFirstTextNode(pre)
         ?.textContent.toLocaleLowerCase()
-        .replaceAll(/['"]/g, "");
+        .replaceAll(/['"]/g, "")
+        .replaceAll(/\s+/g, "-");
       lang && code?.classList.add(`language-${lang}`);
       pre.innerHTML = "";
       pre.appendChild(code);


### PR DESCRIPTION
## Summary
Fixes InvalidCharacterError when copying code blocks with language names containing spaces.

## Changes
- Added `.replaceAll(/\s+/g, "-")` to sanitize language names in both `setCodeBlockLanguage` and `setCodeText` functions
- Spaces in language names are now replaced with hyphens before adding as CSS classes

## Related Issue
Closes #17

## Testing
- Tested with code blocks containing language names like "code snippet"
- Verified that language classes are properly formatted without spaces

## Checklist
- [x] Bug fix (non-breaking change)
- [x] Code follows project style guidelines
- [x] Changes are minimal and focused